### PR TITLE
Pragma for short-circuit evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/gamescripts
-          key: rpu-and-modderpack-gamescripts-v1004
+          key: rpu-and-modderpack-gamescripts-v1005
 
       - name: Download RPU scripts & modderspack
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-rpu-check')
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/gamescripts
-          key: rpu-and-modderpack-gamescripts-v1004
+          key: rpu-and-modderpack-gamescripts-v1005
       - name: Download RPU scripts & modderspack
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-rpu-check')
         shell: bash
@@ -234,7 +234,7 @@ jobs:
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-rpu-check')
         with:
           path: test/gamescripts
-          key: rpu-and-modderpack-gamescripts-v1004
+          key: rpu-and-modderpack-gamescripts-v1005
           fail-on-cache-miss: true
       - name: Test on Fallout RPU
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-rpu-check')
@@ -283,7 +283,7 @@ jobs:
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-rpu-check')
         with:
           path: test/gamescripts
-          key: rpu-and-modderpack-gamescripts-v1004
+          key: rpu-and-modderpack-gamescripts-v1005
           fail-on-cache-miss: true
       - name: Test on Fallout RPU
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-rpu-check')

--- a/docs/sslc_readme.md
+++ b/docs/sslc_readme.md
@@ -322,6 +322,8 @@ Syntax which requires sfall for compiled scripts to be interpreted is marked by 
   If you want to add additional condition for continuing the loop, use syntax: `foreach (<symbol> in <expression> while <expression>)`. In this case loop will iterate over elements of an array until last element or until "while" expression is true (whatever comes first).
 
   __NOTE:__ Just like `for` loop, `continue` statement will respect increments of a hidden counter variable, so you can safely use it inside `foreach`.
+  
+- `#pragma sce` directive. If present anywhere in the compiled script, will enable short-circuit evaluation of logical `and` and `or` operators, even if `-s` command line argument is not used.
 
 ---
 
@@ -347,6 +349,9 @@ There are several changes in this version of sslc which may result in problems f
 ---
 
 ### Changelog
+
+**sfall 4.4.10:**
+- added #pragma sce
 
 **sfall 4.4.7:**
 - fixed leftover stack data caused by the `break` statement

--- a/lex.c
+++ b/lex.c
@@ -37,6 +37,7 @@ static void AppendToAssignCache() {
 }
 
 extern int backwardcompat;
+extern int shortCircuit;
 
 static int ungotToken = -1;
 static int lastToken = -1;
@@ -634,6 +635,38 @@ top:
 						stream->name=AddFileName(buf[which]);
 					}
 					else if (c == EOF)
+						ungetChar();
+				}
+			}
+			else if (_stricmp(buf[which], "pragma") == 0) { // pragma directives
+				do {
+					c = getChar();
+				} while(c != EOF && c != '\n' && !validSymbolChar(c));
+
+				if (c == EOF) {
+					ungetChar();
+				}
+				else if (validSymbolChar(c)) {
+
+					buf[which][0] = c;
+
+					i = 0;
+					while(1) {
+						c = getChar();
+
+						if (!validSymbolChar(c) && c != '-')
+							break;
+
+						buf[which][i+1] = c;
+						i++;
+					}
+
+					buf[which][i+1] = 0;
+
+					if (_stricmp(buf[which], "sce") == 0 && !shortCircuit) {
+						shortCircuit = 1;
+					}
+					if (c == EOF)
 						ungetChar();
 				}
 			}

--- a/parse.c
+++ b/parse.c
@@ -28,7 +28,7 @@ extern int warnings;
 extern int optimize;
 extern int debug;
 extern int dumpTree;
-extern int shortCircuit;
+
 void optimizeTree(Program *program);
 
 /*


### PR DESCRIPTION
Added support for `#pragma sce` for convenient enabling of short-circuit evaluation on a per-script basis

Testing methods:

- Looked at int2ssl dump of the script with and without pragma to confirm SCE opcode patterns.
- In-game test of the same script with and without pragma that checks for side effects in procedure that's not called with SCE enabled.